### PR TITLE
Fixing security issue: setOp now in try-finally

### DIFF
--- a/src/main/java/com/github/sirblobman/join/commands/spigot/object/ServerJoinCommand.java
+++ b/src/main/java/com/github/sirblobman/join/commands/spigot/object/ServerJoinCommand.java
@@ -164,9 +164,12 @@ public final class ServerJoinCommand {
             return;
         }
 
-        player.setOp(true);
-        runAsPlayer(player, command);
-        player.setOp(false);
+        try {
+            player.setOp(true);
+            runAsPlayer(player, command);
+        } finally {
+            player.setOp(false);
+        }
     }
 
     private void runAsConsole(String command) {


### PR DESCRIPTION
It is very important that a `setOp` execution has a FINALLY block so that it will definitely de-op again.

Other plugins must do the same ([example](https://github.com/filoghost/TouchscreenHolograms/blob/c21628ec221742b065273349c49229b2a015dac2/src/main/java/me/filoghost/touchscreenholograms/touch/TouchCommand.java#L70-L75)).